### PR TITLE
fixes the pagination issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ next-env.d.ts
 venv
 
 .env.local
+.env

--- a/src/utils/FormInputHandling.ts
+++ b/src/utils/FormInputHandling.ts
@@ -6,8 +6,7 @@ import { formatTimeForPicker } from "./TimeFormatter";
 // get data from the db when session id is generated
 async function getData(
   currentPage: number,
-  limit: number,
-  string_query: string | undefined
+  limit: number
 ) {
   const offset = currentPage * limit;
   const { data } = await instance.get<DbTypes[]>(`api`);

--- a/src/utils/FormInputHandling.ts
+++ b/src/utils/FormInputHandling.ts
@@ -4,17 +4,24 @@ import { formatDateForPicker } from "./TimeFormatter";
 import { formatTimeForPicker } from "./TimeFormatter";
 
 // get data from the db when session id is generated
-async function getData(currentPage: number, limit: number) {
+async function getData(
+  currentPage: number,
+  limit: number,
+  string_query: string | undefined
+) {
   const offset = currentPage * limit;
-  const { data } = await instance.get<DbTypes[]>(`api`)
-  const hasMore = data.length > limit;
-  const items = hasMore ? data.slice(0, -1) : data;
-
+  const { data } = await instance.get<DbTypes[]>(`api`);
+    // pagination
+  //to check is there any more entry present or not
+  const hasMore = data.length>(limit+offset);
+  const limit_idx = offset + (hasMore?limit:data.length);
+  const items = data.slice(offset, limit_idx);
   return {
     data: items,
     hasMore,
-  };
-}
+  }
+};
+
 
 async function getASession(id: number) {
   const { data } = await instance.get<DbTypes>(`api/${id}`);


### PR DESCRIPTION
Fixes the issue #51 

There is an issue with the pagination feature in the application. The expected behavior is that each page should display a maximum of 10 entries, as per the specified limit. However, currently, the application is showing all entries on the first page only, disregarding the set limit. This results in a single page containing all entries, which can negatively impact the user experience and performance, especially with a large dataset.

**Steps to Reproduce:**

Navigate to the list of entries in the application.
Observe the pagination behavior.

**Expected Behavior:**
Each page should display a maximum of 10 entries.

**Actual Behavior:**
All entries are displayed on a single page.