### PR TITLE
Handle Register Sessions

### DIFF
--- a/src/Constants/Options.ts
+++ b/src/Constants/Options.ts
@@ -9,7 +9,8 @@ export const TestTypeOptions: Option[] = [
 export const SessionTypeOptions: Option[] = [
   { value: 'sign-in', label: 'SignIn' },
   { value: 'sign-up', label: 'SignUp' },
-  { value: 'sign-in with forgot id', label: 'SignIn with Forgot ID' },
+  // Removed as now we are not allowing forgot id
+  // { value: 'sign-in with forgot id', label: 'SignIn with Forgot ID' },
   { value: 'broadcast', label: 'Broadcast' },
 ];
 

--- a/src/app/(home)/Table/Actions.tsx
+++ b/src/app/(home)/Table/Actions.tsx
@@ -49,6 +49,7 @@ const TableActions = ({ session }: { session: Session }) => {
               await patchSession(
                 {
                   is_active: !session.is_active,
+                  meta_data: session.meta_data,
                 },
                 session.id ?? 0,
                 session

--- a/src/app/session/[type]/Steps/helper.ts
+++ b/src/app/session/[type]/Steps/helper.ts
@@ -25,7 +25,6 @@ export const setGroupPreset = (value: string, form: UseFormReturn, apiOptions: A
         isPopupForm: false,
         popupFormId: null,
         noOfFieldsInPopup: '',
-        isRedirection: true,
         isIdGeneration: false,
         parentBatch: '',
         subBatch: [],
@@ -43,7 +42,6 @@ export const setGroupPreset = (value: string, form: UseFormReturn, apiOptions: A
         isPopupForm: false,
         popupFormId: null,
         noOfFieldsInPopup: '',
-        isRedirection: true,
         isIdGeneration: true,
         parentBatch: '',
         subBatch: [],
@@ -62,7 +60,6 @@ export const setGroupPreset = (value: string, form: UseFormReturn, apiOptions: A
         isPopupForm: false,
         popupFormId: null,
         noOfFieldsInPopup: '',
-        isRedirection: true,
         isIdGeneration: false,
         parentBatch: '',
         subBatch: [],
@@ -78,7 +75,6 @@ export const setGroupPreset = (value: string, form: UseFormReturn, apiOptions: A
         isPopupForm: false,
         popupFormId: null,
         noOfFieldsInPopup: '',
-        isRedirection: true,
         isIdGeneration: false,
         parentBatch: '',
         subBatch: [],
@@ -92,7 +88,6 @@ export const setGroupPreset = (value: string, form: UseFormReturn, apiOptions: A
         isPopupForm: false,
         popupFormId: null,
         noOfFieldsInPopup: '',
-        isRedirection: true,
         isIdGeneration: false,
         parentBatch: '',
         subBatch: [],
@@ -283,6 +278,9 @@ export const handleBatchFields = (
     fieldsSchema.parentBatch.hide = false;
   }
 
+  if (value === Platform.NoPlatform) {
+    form.setValue('isRedirection', false, { shouldDirty: true });
+  }
   const selectedGroup = form.watch('group');
   if (selectedGroup) {
     setParentBatchOptions(selectedGroup, form, apiOptions, fieldsSchema);

--- a/src/app/session/[type]/Steps/helper.ts
+++ b/src/app/session/[type]/Steps/helper.ts
@@ -280,6 +280,8 @@ export const handleBatchFields = (
 
   if (value === Platform.NoPlatform) {
     form.setValue('isRedirection', false, { shouldDirty: true });
+  } else {
+    form.setValue('isRedirection', true, { shouldDirty: true });
   }
   const selectedGroup = form.watch('group');
   if (selectedGroup) {

--- a/src/lib/time-picker-utils.ts
+++ b/src/lib/time-picker-utils.ts
@@ -171,12 +171,14 @@ export function display12HourValue(hours: number) {
 }
 
 export function utcToISTDate(utcDate: string) {
+  if (!utcDate) return '';
   const parsedDate = new Date(utcDate);
   const istDate = addMinutes(parsedDate, UTC_IST_OFFSET).toISOString();
   return istDate;
 }
 
 export function istToUTCDate(istDate: string) {
+  if (!istDate) return '';
   const parsedDate = new Date(istDate);
   const utcDate = subMinutes(parsedDate, UTC_IST_OFFSET).toISOString();
   return utcDate;

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -39,7 +39,7 @@ const repeatScheduleSchema = z.object({
 });
 
 export const sessionSchema = z.object({
-  auth_type: z.string(),
+  auth_type: z.string().nullable(),
   created_by_id: z.string().datetime(),
   end_time: z.string().datetime(),
   id: z.number().int(),
@@ -48,7 +48,7 @@ export const sessionSchema = z.object({
   meta_data: metaDataSchema,
   name: z.string(),
   owner_id: z.string(),
-  platform: z.string(),
+  platform: z.string().nullable(),
   platform_id: z.string(),
   platform_link: z.string().url(),
   popup_form: z.boolean(),

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -48,7 +48,7 @@ export const sessionSchema = z.object({
   meta_data: metaDataSchema,
   name: z.string(),
   owner_id: z.string(),
-  platform: z.string().nullable(),
+  platform: z.string(),
   platform_id: z.string(),
   platform_link: z.string().url(),
   popup_form: z.boolean(),

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -24,6 +24,7 @@ export enum Platform {
   Others = 'others',
   Plio = 'AF-plio',
   SPlio = 'SCERT-plio',
+  NoPlatform = 'no-platform',
 }
 
 export enum Group {

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -67,10 +67,11 @@ export const GroupShortName: Record<Group, string> = {
 
 export enum AuthType {
   ID = 'ID',
-  IDPH = 'ID,PH',
   IDDOB = 'ID,DOB',
-  IDPHDOB = 'ID,PH,DOB',
   CODE = 'CODE',
+  // Removed as now we are not allowing these.
+  // IDPH = 'ID,PH',
+  // IDPHDOB = 'ID,PH,DOB',
 }
 
 export enum Subjects {

--- a/src/types/form.types.ts
+++ b/src/types/form.types.ts
@@ -6,6 +6,7 @@ import {
   SessionTypeOptions,
   StreamOptions,
   TestFormatOptions,
+  TestPlatformOptions,
   TestPurposeOptions,
   TestTypeOptions,
 } from '@/Constants';
@@ -49,7 +50,12 @@ export const basicSchema = z
     isIdGeneration: z.coerce.boolean(),
     signupFormId: z.coerce.number().optional().nullable(),
     popupFormId: z.coerce.number().optional().nullable(),
-    platform: z.string({ required_error: 'This field is required' }).optional().nullable(),
+    platform: z
+      .string({ required_error: 'This field is required' })
+      .refine(
+        (value) => TestPlatformOptions.some((option) => option.value === value),
+        'Invalid option selected'
+      ),
     name: z.string({ required_error: 'This field is required' }).min(1, 'This field is required'),
   })
   .superRefine((data, context) => {
@@ -82,14 +88,6 @@ export const basicSchema = z
 
     // Validation for sessions with Redirection = true
     if (data.isRedirection) {
-      if (!data.platform) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: 'This field is required',
-          path: ['platform'],
-        });
-      }
-
       if (!data.authType) {
         context.addIssue({
           code: z.ZodIssueCode.custom,

--- a/src/types/form.types.ts
+++ b/src/types/form.types.ts
@@ -6,7 +6,6 @@ import {
   SessionTypeOptions,
   StreamOptions,
   TestFormatOptions,
-  TestPlatformOptions,
   TestPurposeOptions,
   TestTypeOptions,
 } from '@/Constants';
@@ -35,7 +34,7 @@ export const basicSchema = z
         (value) => SessionTypeOptions.some((option) => option.value === value),
         'Invalid option selected'
       ),
-    authType: z.string({ required_error: 'This field is required' }),
+    authType: z.string({ required_error: 'This field is required' }).optional().nullable(),
     activateSignUp: z.coerce.boolean(),
     isPopupForm: z.coerce.boolean(),
     noOfFieldsInPopup: z.coerce
@@ -50,12 +49,7 @@ export const basicSchema = z
     isIdGeneration: z.coerce.boolean(),
     signupFormId: z.coerce.number().optional().nullable(),
     popupFormId: z.coerce.number().optional().nullable(),
-    platform: z
-      .string({ required_error: 'This field is required' })
-      .refine(
-        (value) => TestPlatformOptions.some((option) => option.value === value),
-        'Invalid option selected'
-      ),
+    platform: z.string({ required_error: 'This field is required' }).optional().nullable(),
     name: z.string({ required_error: 'This field is required' }).min(1, 'This field is required'),
   })
   .superRefine((data, context) => {
@@ -82,6 +76,25 @@ export const basicSchema = z
           code: z.ZodIssueCode.custom,
           message: 'This field is required',
           path: ['signupFormId'],
+        });
+      }
+    }
+
+    // Validation for sessions with Redirection = true
+    if (data.isRedirection) {
+      if (!data.platform) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'This field is required',
+          path: ['platform'],
+        });
+      }
+
+      if (!data.authType) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'This field is required',
+          path: ['authType'],
         });
       }
     }

--- a/src/types/form.types.ts
+++ b/src/types/form.types.ts
@@ -227,7 +227,7 @@ export const liveSchema = z
       .pipe(z.string().url('This is not a valid url')),
     platformId: z.string({ required_error: 'This field is required' }),
     subject: z.array(z.string()).min(1, 'This field is required'),
-    platform: z.string().optional(),
+    platform: z.string().optional().nullable(),
   })
   .refine(
     (data) => {


### PR DESCRIPTION
- Added a platform - `no-platform`
- Allow edit to register sessions by removing the required property of auth field if `isRedirection` is false.
- Remove `ID,PH`, `ID,PH,DOB` auth options
- Remove Signup `sign-in with forgot id`


Preview: https://handle-registration.dauyvuo7dvzau.amplifyapp.com/

Tested: Create & edit of registration sessions. 