### PR TITLE
Added default options so the form can be submitted 

### DIFF
--- a/src/app/session/[type]/Steps/Basic/index.tsx
+++ b/src/app/session/[type]/Steps/Basic/index.tsx
@@ -32,6 +32,7 @@ const BasicForm: FC = () => {
   const { formData, apiOptions = {}, updateFormData } = useFormContext();
   const isMounted = useRef(false);
 
+  console.log(apiOptions?.group?.length);
   let fieldsSchema: FieldSchema<basicFields> = useMemo(
     () => ({
       name: {
@@ -50,7 +51,7 @@ const BasicForm: FC = () => {
       },
       group: {
         type: 'select',
-        options: apiOptions?.group,
+        options: apiOptions?.group?.length == 0 ? opt : apiOptions?.group,
         placeholder: 'Select a group',
         label: 'Group',
         disabled: type === SessionType.EDIT,
@@ -69,6 +70,7 @@ const BasicForm: FC = () => {
         onValueChange: (value, form) => {
           setBatchOptions(value, form, apiOptions, fieldsSchema);
         },
+        options: opt,
       },
       subBatch: {
         type: 'multi-select',


### PR DESCRIPTION
Added default options (['a', 'b', 'c']) for required select fields like group, parentBatch, and subBatch to prevent form submission issues when apiOptions is empty. This ensures a smoother user experience and avoids blocked submissions.