### PR TITLE
Timeout for pending sessinos

### DIFF
--- a/src/hooks/useStuckPendingTimeout.tsx
+++ b/src/hooks/useStuckPendingTimeout.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { Session, STATUS } from '@/types';
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * Hook to detect and handle stuck PENDING sessions
+ * If a session stays PENDING for more than 2 minutes,
+ * mark it as FAILED on the server to stop showing spinner
+ */
+const useStuckPendingTimeout = (data: Session[], onSessionExpired?: (session: Session) => void) => {
+  const pendingTimestamps = useRef<Map<number, { timestamp: number; session: Session }>>(new Map());
+
+  const STUCK_TIMEOUT = 2 * 60 * 1000; // 2 minutes
+
+  // Track when sessions enter PENDING state with full session data
+  useEffect(() => {
+    const now = Date.now();
+
+    data?.forEach((session) => {
+      if (session?.id && session?.meta_data?.status === STATUS.PENDING) {
+        // First time seeing this session in PENDING
+        if (!pendingTimestamps.current.has(session.id)) {
+          pendingTimestamps.current.set(session.id, { timestamp: now, session });
+        }
+      } else if (session?.id) {
+        // Session is no longer PENDING, remove from tracking
+        pendingTimestamps.current.delete(session.id);
+      }
+    });
+  }, [data]);
+
+  // Check for stuck sessions periodically
+  useEffect(() => {
+    const checkInterval = setInterval(() => {
+      const now = Date.now();
+      const stuckSessions: Session[] = [];
+
+      pendingTimestamps.current.forEach(({ timestamp, session }) => {
+        const elapsedTime = now - timestamp;
+        if (elapsedTime > STUCK_TIMEOUT) {
+          stuckSessions.push(session);
+        }
+      });
+
+      // Notify about stuck sessions
+      stuckSessions.forEach((session) => {
+        onSessionExpired?.(session);
+        // Remove from tracking so we don't notify again
+        pendingTimestamps.current.delete(session.id!);
+      });
+    }, 10000); // Check every 10 seconds
+
+    return () => clearInterval(checkInterval);
+  }, [onSessionExpired]);
+
+  return {
+    stuckSessions: Array.from(pendingTimestamps.current.keys()),
+  };
+};
+
+export default useStuckPendingTimeout;

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -207,6 +207,36 @@ export async function patchSession(formData: Session, id: number, oldSession: Se
 }
 
 /**
+ * Marks a session as FAILED on the server due to timeout/stuck PENDING state
+ * @param {Session} session - The full session object to preserve metadata
+ * @return {Promise<{isSuccess: boolean}>}
+ */
+export async function markSessionAsFailed(session: Session) {
+  try {
+    if (!session?.id) {
+      console.error('Invalid session: missing id');
+      return { isSuccess: false };
+    }
+
+    // Merge entire meta_data with status update
+    const payload: Session = {
+      ...session,
+      meta_data: {
+        ...session.meta_data,
+        status: STATUS.FAILED,
+      },
+    };
+
+    await instance.patch<Session>(`/session/${session.id}`, payload);
+    console.info(`[SUCCESS] marked session ${session.id} as failed due to timeout`);
+    return { isSuccess: true };
+  } catch (error) {
+    console.error(`Error marking session as failed:`, error);
+    return { isSuccess: false };
+  }
+}
+
+/**
  * Fetch required data from the server
  * - group: List of groups
  * - batch: List of batches


### PR DESCRIPTION
If the sessions are in PENDING state for too long, set them to FAILED and disable the loading spinner