### PR TITLE
Tag and hide LMS-created sessions

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -9,6 +9,12 @@ import { cache } from 'react';
 import { instance } from '../lib/axios';
 import { publishMessage } from './Aws';
 
+const HIDDEN_SESSION_SOURCES = new Set(['lms']);
+
+function isHiddenSession(session: Session) {
+  return HIDDEN_SESSION_SOURCES.has(String(session.meta_data?.created_from ?? '').toLowerCase());
+}
+
 /**
  * Retrieves sessions data from the server.
  *
@@ -36,7 +42,8 @@ export async function getSessions(filterParams: FilterParams) {
     }));
 
     const hasMore = data.length === filterParams.limit;
-    const items = hasMore ? parsedData.slice(0, -1) : parsedData;
+    const pageData = hasMore ? parsedData.slice(0, -1) : parsedData;
+    const items = pageData.filter((session) => !isHiddenSession(session));
     console.info('[API SUCCESS] fetching sessions : ', {
       length: items.length,
       hasMore,
@@ -124,6 +131,7 @@ export async function createSession(formData: Session) {
           infinite_session: false,
           status: STATUS.PENDING,
           date_created: utcToISTDate(new Date().toISOString()),
+          created_from: 'session_manager',
         },
         purpose: {
           type: 'attendance',
@@ -140,6 +148,7 @@ export async function createSession(formData: Session) {
           ...formData.meta_data,
           status: STATUS.PENDING,
           date_created: utcToISTDate(new Date().toISOString()),
+          created_from: 'session_manager',
         },
         purpose: '',
         start_time: utcToISTDate(formData.start_time ?? ''),

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -8,6 +8,8 @@ const metaDataSchema = z.object({
   batch_id: z.string().optional(),
   cms_test_id: z.string().url().optional(),
   course: z.string().optional(),
+  created_by: z.string().optional(),
+  created_from: z.string().optional(),
   date_created: z.string().datetime().optional(),
   enabled: z.number().int().optional(),
   grade: z.number().int().optional(),


### PR DESCRIPTION
## Summary
- tag new session-manager-created sessions with created_from=session_manager
- hide LMS-created sessions from the session manager list using created_from=lms
- keep legacy [LMS] name filtering as a fallback

## Verification
- source ~/.nvm/nvm.sh && nvm use 20.17.0 >/dev/null && npm run lint:check -- src/services/services.ts src/types/api.types.ts