### PR TITLE
Show recent batch families in session creator

### DIFF
--- a/cypress/mocks/mockdata.ts
+++ b/cypress/mocks/mockdata.ts
@@ -19,15 +19,15 @@ export const CreateQuizData = {
   platform: { label: Platform.Quiz, value: Platform.Quiz },
   group: { label: Group.Haryana, value: Group.Haryana },
   parentBatch: {
-    label: 'HR-9-Foundation-24',
-    value: 'HR-9-Foundation-24',
-    name: 'Haryana 9 Quiz Batch - 24',
+    label: 'HR-9-Foundation-25',
+    value: 'HR-9-Foundation-25',
+    name: 'Haryana 9 Quiz Batch - 25',
   },
   subBatch: [
     {
-      label: 'HaryanaStudents_9_Foundation_24_001',
-      value: 'HaryanaStudents_9_Foundation_24_001',
-      name: '9B01',
+      label: 'HaryanaStudents_9_Foundation_25_001',
+      value: 'HaryanaStudents_9_Foundation_25_001',
+      name: '9B01 2025',
     },
   ],
   grade: GradeOptions.find((i) => i.value === 9)!,
@@ -85,14 +85,14 @@ export const CreateLiveData = {
   group: { label: Group.Haryana, value: Group.Haryana },
   subBatch: [
     {
-      label: 'HaryanaStudents_9_Foundation_24_001',
-      value: 'HaryanaStudents_9_Foundation_24_001',
-      name: '9B01',
+      label: 'HaryanaStudents_9_Foundation_25_001',
+      value: 'HaryanaStudents_9_Foundation_25_001',
+      name: '9B01 2025',
     },
     {
-      label: 'HaryanaStudents_10_Foundation_24_001',
-      value: 'HaryanaStudents_10_Foundation_24_001',
-      name: '10B01',
+      label: 'HaryanaStudents_10_Foundation_25_001',
+      value: 'HaryanaStudents_10_Foundation_25_001',
+      name: '10B01 2025',
     },
   ],
   grade: GradeOptions.find((i) => i.value === 9)!,

--- a/docs/SESSION_CREATOR_GUIDE.md
+++ b/docs/SESSION_CREATOR_GUIDE.md
@@ -95,6 +95,9 @@ The batch dropdowns are not a raw full list. They are filtered by group and by p
 
 - quiz sessions use parent batches
 - live sessions use child batches
+- batch IDs with a cohort year from the current or previous calendar year are shown first and
+  remain selectable; older families are hidden when a group has recent families
+- groups without any recent parseable batch IDs retain their existing options as a fallback
 
 There are also special mappings for school groups:
 

--- a/src/app/(home)/Table/Filters.tsx
+++ b/src/app/(home)/Table/Filters.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button';
+import { isSelectableBatchOption } from '@/lib/batch-options';
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -62,14 +63,18 @@ const Filters = ({ table, apiOptions }: { table: Table<Session>; apiOptions: Api
     if (groupFilter) {
       const authGroupId = apiOptions.group?.find((item) => item.value === groupFilter)?.id;
       const filteredQuizBatchOptions =
-        apiOptions?.batch?.filter((item) => item.groupId === authGroupId && !item.parentId) ?? [];
+        apiOptions?.batch?.filter(
+          (item) => item.groupId === authGroupId && !item.parentId && isSelectableBatchOption(item)
+        ) ?? [];
       fields.parentId.options = filteredQuizBatchOptions;
       fields.parentId.show = true;
 
       if (parentIdFilter) {
         const quizBatchId = apiOptions.batch?.find((item) => item.value === parentIdFilter)?.id;
         const filteredClassBatchOptions =
-          apiOptions?.batch?.filter((item) => item.parentId === quizBatchId) ?? [];
+          apiOptions?.batch?.filter(
+            (item) => item.parentId === quizBatchId && isSelectableBatchOption(item)
+          ) ?? [];
         fields.batchId.options = filteredClassBatchOptions;
         fields.batchId.show = true;
       }

--- a/src/app/session/[type]/Steps/Basic/index.tsx
+++ b/src/app/session/[type]/Steps/Basic/index.tsx
@@ -3,8 +3,10 @@
 import { AuthOptions, GradeOptions, SessionTypeOptions, TestPlatformOptions } from '@/Constants';
 import { FormBuilder } from '@/components/FormBuilder';
 import { useFormContext } from '@/hooks/useFormContext';
+import { isSelectableBatchOption } from '@/lib/batch-options';
 import {
   FieldSchema,
+  ExtendedOptions,
   Platform,
   Session,
   SessionParams,
@@ -45,6 +47,14 @@ const BasicForm: FC = () => {
         return { parentBatchOptions: [], subBatchOptions: [] };
       }
 
+      const selectedBatchIds = new Set(
+        formData?.meta_data?.batch_id?.split(',').map((batchId) => batchId.trim()) ?? []
+      );
+      const isAvailableBatch = (item: ExtendedOptions) =>
+        isSelectableBatchOption(item) ||
+        item.value === formData?.meta_data?.parent_id ||
+        selectedBatchIds.has(String(item.value));
+
       let filteredBatchOptions: any[] = [];
 
       // Apply the same filtering logic as setParentBatchOptions
@@ -53,7 +63,9 @@ const BasicForm: FC = () => {
         filteredBatchOptions =
           apiOptions?.batch?.filter(
             (item) =>
-              item.groupId === TNStudentsId && (isQuizSession ? !item.parentId : !!item.parentId)
+              item.groupId === TNStudentsId &&
+              (isQuizSession ? !item.parentId : !!item.parentId) &&
+              isAvailableBatch(item)
           ) ?? [];
       } else if (authGroupSelected.value === Group.GujaratSchools) {
         const GujaratStudentsId = apiOptions.group?.find(
@@ -63,7 +75,8 @@ const BasicForm: FC = () => {
           apiOptions?.batch?.filter(
             (item) =>
               item.groupId === GujaratStudentsId &&
-              (isQuizSession ? !item.parentId : !!item.parentId)
+              (isQuizSession ? !item.parentId : !!item.parentId) &&
+              isAvailableBatch(item)
           ) ?? [];
       } else if (authGroupSelected.value === Group.PunjabSchools) {
         const PunjabStudentsId = apiOptions.group?.find(
@@ -73,7 +86,8 @@ const BasicForm: FC = () => {
           apiOptions?.batch?.filter(
             (item) =>
               item.groupId === PunjabStudentsId &&
-              (isQuizSession ? !item.parentId : !!item.parentId)
+              (isQuizSession ? !item.parentId : !!item.parentId) &&
+              isAvailableBatch(item)
           ) ?? [];
       } else if (authGroupSelected.value === Group.EnableSchools) {
         const EnableStudentsId = apiOptions.group?.find((item) => item.value === Group.Enable)?.id;
@@ -81,14 +95,16 @@ const BasicForm: FC = () => {
           apiOptions?.batch?.filter(
             (item) =>
               item.groupId === EnableStudentsId &&
-              (isQuizSession ? !item.parentId : !!item.parentId)
+              (isQuizSession ? !item.parentId : !!item.parentId) &&
+              isAvailableBatch(item)
           ) ?? [];
       } else {
         filteredBatchOptions =
           apiOptions?.batch?.filter(
             (item) =>
               item.groupId === authGroupSelected?.id &&
-              (isQuizSession ? !item.parentId : !!item.parentId)
+              (isQuizSession ? !item.parentId : !!item.parentId) &&
+              isAvailableBatch(item)
           ) ?? [];
       }
 
@@ -102,7 +118,9 @@ const BasicForm: FC = () => {
             (item) => item.value === formData.meta_data?.parent_id
           )?.id;
           subBatchOptions =
-            apiOptions?.batch?.filter((item) => item.parentId === quizBatchId) ?? [];
+            apiOptions?.batch?.filter(
+              (item) => item.parentId === quizBatchId && isAvailableBatch(item)
+            ) ?? [];
         }
 
         return { parentBatchOptions, subBatchOptions };
@@ -110,7 +128,12 @@ const BasicForm: FC = () => {
         return { parentBatchOptions: [], subBatchOptions: filteredBatchOptions };
       }
     },
-    [apiOptions?.batch, apiOptions?.group, formData?.meta_data?.parent_id]
+    [
+      apiOptions?.batch,
+      apiOptions?.group,
+      formData?.meta_data?.batch_id,
+      formData?.meta_data?.parent_id,
+    ]
   );
 
   // Get current batch options reactively

--- a/src/app/session/[type]/Steps/helper.ts
+++ b/src/app/session/[type]/Steps/helper.ts
@@ -13,6 +13,7 @@ import {
   basicFields,
   quizFields,
 } from '@/types';
+import { isSelectableBatchOption } from '@/lib/batch-options';
 import { UseFormReturn } from 'react-hook-form';
 
 export const setGroupPreset = (value: string, form: UseFormReturn, apiOptions: ApiFormOptions) => {
@@ -120,7 +121,10 @@ export const setParentBatchOptions = (
 
     filteredQuizBatchOptions =
       apiOptions?.batch?.filter(
-        (item) => item.groupId === TNStudentsId && !item.parentId === isQuizSession
+        (item) =>
+          item.groupId === TNStudentsId &&
+          !item.parentId === isQuizSession &&
+          isSelectableBatchOption(item)
       ) ?? [];
   } else if (authGroupSelected?.value == Group.GujaratSchools) {
     const GujaratStudentsId = apiOptions.group?.find(
@@ -129,7 +133,10 @@ export const setParentBatchOptions = (
 
     filteredQuizBatchOptions =
       apiOptions?.batch?.filter(
-        (item) => item.groupId === GujaratStudentsId && !item.parentId === isQuizSession
+        (item) =>
+          item.groupId === GujaratStudentsId &&
+          !item.parentId === isQuizSession &&
+          isSelectableBatchOption(item)
       ) ?? [];
   } else if (authGroupSelected?.value == Group.PunjabSchools) {
     const PunjabStudentsId = apiOptions.group?.find(
@@ -138,19 +145,28 @@ export const setParentBatchOptions = (
 
     filteredQuizBatchOptions =
       apiOptions?.batch?.filter(
-        (item) => item.groupId === PunjabStudentsId && !item.parentId === isQuizSession
+        (item) =>
+          item.groupId === PunjabStudentsId &&
+          !item.parentId === isQuizSession &&
+          isSelectableBatchOption(item)
       ) ?? [];
   } else if (authGroupSelected?.value == Group.EnableSchools) {
     const EnableStudentsId = apiOptions.group?.find((item) => item.value === Group.Enable)?.id;
 
     filteredQuizBatchOptions =
       apiOptions?.batch?.filter(
-        (item) => item.groupId === EnableStudentsId && !item.parentId === isQuizSession
+        (item) =>
+          item.groupId === EnableStudentsId &&
+          !item.parentId === isQuizSession &&
+          isSelectableBatchOption(item)
       ) ?? [];
   } else {
     filteredQuizBatchOptions =
       apiOptions?.batch?.filter(
-        (item) => item.groupId === authGroupSelected?.id && !item.parentId === isQuizSession
+        (item) =>
+          item.groupId === authGroupSelected?.id &&
+          !item.parentId === isQuizSession &&
+          isSelectableBatchOption(item)
       ) ?? [];
   }
 
@@ -206,7 +222,7 @@ export const setBatchOptions = (
 
   const quizBatchId = apiOptions.batch?.find((item) => item.value === value)?.id;
   const filteredClassBatchOptions = apiOptions?.batch?.filter(
-    (item) => item.parentId === quizBatchId
+    (item) => item.parentId === quizBatchId && isSelectableBatchOption(item)
   );
   form.setValue('subBatch', []);
   (fieldsSchema.subBatch as MySelectProps).options = filteredClassBatchOptions ?? [];

--- a/src/lib/batch-options.test.ts
+++ b/src/lib/batch-options.test.ts
@@ -1,0 +1,85 @@
+import {
+  inferBatchYear,
+  isSelectableBatchOption,
+  markSelectableBatchFamilies,
+} from './batch-options';
+
+describe('batch options', () => {
+  test.each([
+    ['CG-TP-2027-common-A01', 2027],
+    ['ChhattisgarhStudents_TP_2028_common_A001', 2028],
+    ['CG-12-A25', 2025],
+    ['ChhattisgarhStudents_12_24_A001', 2024],
+    ['AF-Testing', undefined],
+  ])('infers the cohort year from %s', (batchId, expectedYear) => {
+    expect(inferBatchYear(batchId)).toBe(expectedYear);
+  });
+
+  it('keeps recent parent/class families and marks older families as non-selectable', () => {
+    const batches = markSelectableBatchFamilies(
+      [
+        { id: '396', value: 'CG-12-A24', groupId: '19' },
+        {
+          id: '397',
+          value: 'ChhattisgarhStudents_12_24_A001',
+          parentId: '396',
+          groupId: '19',
+        },
+        { id: '821', value: 'CG-12-A25', groupId: '19' },
+        {
+          id: '822',
+          value: 'ChhattisgarhStudents_12_25_A001',
+          parentId: '821',
+          groupId: '19',
+        },
+        { id: '1078', value: 'CG-TP-2027-common-A01', groupId: '19' },
+        {
+          id: '1080',
+          value: 'ChhattisgarhStudents_TP_2027_common_A001',
+          parentId: '1078',
+          groupId: '19',
+        },
+      ],
+      2026
+    );
+
+    expect(batches).toHaveLength(6);
+    const selectableValues = batches.filter(isSelectableBatchOption).map((batch) => batch.value);
+    expect(selectableValues).toHaveLength(4);
+    expect(selectableValues).toEqual(
+      expect.arrayContaining([
+        'CG-12-A25',
+        'ChhattisgarhStudents_12_25_A001',
+        'CG-TP-2027-common-A01',
+        'ChhattisgarhStudents_TP_2027_common_A001',
+      ])
+    );
+  });
+
+  it('inherits the parent year for class batches without a year in their ID', () => {
+    const batches = markSelectableBatchFamilies(
+      [
+        { id: '10', value: 'PROGRAM-TP-2027-A01', groupId: '1' },
+        { id: '11', value: 'PROGRAM-CLASS-ALPHA', parentId: '10', groupId: '1' },
+      ],
+      2026
+    );
+
+    expect(batches).toEqual([
+      expect.objectContaining({ batchYear: 2027, isSelectableBatch: true }),
+      expect.objectContaining({ batchYear: 2027, isSelectableBatch: true }),
+    ]);
+  });
+
+  it('keeps legacy options when a group has no recent parseable family', () => {
+    const batches = markSelectableBatchFamilies(
+      [
+        { id: '1', value: 'AF-Testing', groupId: '2' },
+        { id: '2', value: 'AF-Teachers-A24', groupId: '3' },
+      ],
+      2026
+    );
+
+    expect(batches.every(isSelectableBatchOption)).toBe(true);
+  });
+});

--- a/src/lib/batch-options.ts
+++ b/src/lib/batch-options.ts
@@ -1,0 +1,67 @@
+import { ExtendedOptions } from '@/types';
+
+export const MAX_BATCH_OPTIONS = 10_000;
+
+const FOUR_DIGIT_YEAR = /(?:^|[_-])(20\d{2})(?=[_-]|$)/;
+const TWO_DIGIT_YEAR = /(?:^|[_-])A?(2\d)(?=[_-]|$)/;
+
+export function inferBatchYear(batchId: string): number | undefined {
+  const fourDigitMatch = batchId.match(FOUR_DIGIT_YEAR);
+  if (fourDigitMatch) return Number(fourDigitMatch[1]);
+
+  const twoDigitMatch = batchId.match(TWO_DIGIT_YEAR);
+  if (twoDigitMatch) return 2000 + Number(twoDigitMatch[1]);
+
+  return undefined;
+}
+
+export function markSelectableBatchFamilies(
+  batches: ExtendedOptions[],
+  currentYear = new Date().getFullYear()
+): ExtendedOptions[] {
+  const cutoffYear = currentYear - 1;
+  const familyYears = new Map<string, number>();
+
+  for (const batch of batches) {
+    const familyId = String(batch.parentId ?? batch.id ?? batch.value);
+    const batchYear = inferBatchYear(String(batch.value ?? ''));
+    if (batchYear == null) continue;
+
+    familyYears.set(familyId, Math.max(familyYears.get(familyId) ?? 0, batchYear));
+  }
+
+  const groupsWithRecentFamilies = new Set<string>();
+  for (const batch of batches) {
+    const familyId = String(batch.parentId ?? batch.id ?? batch.value);
+    const familyYear = familyYears.get(familyId);
+    if (familyYear != null && familyYear >= cutoffYear && batch.groupId != null) {
+      groupsWithRecentFamilies.add(String(batch.groupId));
+    }
+  }
+
+  return batches
+    .map((batch) => {
+      const familyId = String(batch.parentId ?? batch.id ?? batch.value);
+      const familyYear = familyYears.get(familyId);
+      const groupId = batch.groupId == null ? undefined : String(batch.groupId);
+      const groupHasRecentFamilies = groupId != null && groupsWithRecentFamilies.has(groupId);
+
+      return {
+        ...batch,
+        id: batch.id,
+        batchYear: familyYear,
+        isSelectableBatch:
+          (familyYear != null && familyYear >= cutoffYear) || !groupHasRecentFamilies,
+      };
+    })
+    .sort((left, right) => {
+      const yearDifference = (right.batchYear ?? 0) - (left.batchYear ?? 0);
+      if (yearDifference !== 0) return yearDifference;
+
+      return Number(right.id ?? 0) - Number(left.id ?? 0);
+    });
+}
+
+export function isSelectableBatchOption(batch: ExtendedOptions): boolean {
+  return batch.isSelectableBatch !== false;
+}

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -3,6 +3,7 @@
 import { DATA_PER_PAGE, KeysToDeleteBeforeUpdate } from '@/Constants';
 import { istToUTCDate, utcToISTDate } from '@/lib/time-picker-utils';
 import { deleteByPath, filterObject } from '@/lib/utils';
+import { markSelectableBatchFamilies, MAX_BATCH_OPTIONS } from '@/lib/batch-options';
 import { ApiFormOptions, FilterParams, Platform, STATUS, TableParams } from '@/types';
 import { Session } from '@/types/api.types';
 import { cache } from 'react';
@@ -318,19 +319,26 @@ export async function getAuthGroups() {
 
 export async function getBatches() {
   try {
-    const { data } = await instance.get<Record<string, unknown>[]>(`/batch`);
+    const { data } = await instance.get<Record<string, unknown>[]>(`/batch`, {
+      params: { limit: MAX_BATCH_OPTIONS, offset: 0 },
+    });
 
-    const batches = data?.map((item) => ({
-      label: String(item.batch_id ?? ''),
-      value: String(item.batch_id ?? ''),
-      id: item.id == null ? undefined : String(item.id),
-      name: String(item.name ?? ''),
-      parentId: item.parent_id == null ? undefined : String(item.parent_id),
-      groupId: item.auth_group_id == null ? undefined : String(item.auth_group_id),
-    }));
+    const batches = markSelectableBatchFamilies(
+      data?.map((item) => ({
+        label: String(item.batch_id ?? ''),
+        value: String(item.batch_id ?? ''),
+        id: item.id == null ? undefined : String(item.id),
+        name: String(item.name ?? ''),
+        parentId: item.parent_id == null ? undefined : String(item.parent_id),
+        groupId: item.auth_group_id == null ? undefined : String(item.auth_group_id),
+      })) ?? []
+    );
 
+    if (data.length === MAX_BATCH_OPTIONS) {
+      console.warn(`[API WARNING] batch options reached the ${MAX_BATCH_OPTIONS} row cap`);
+    }
     console.info('[API SUCCESS] fetching batches : ', batches.length);
-    return batches ?? [];
+    return batches;
   } catch (error) {
     console.error(`[API ERROR] fetching options : ${error}`);
     return [];


### PR DESCRIPTION
## What changed

- request the complete batch catalogue within db-service's 10,000-row ceiling
- infer cohort years from four-digit (`2027`) and two-digit (`25`/`A25`) batch ID tokens
- keep current and previous calendar-year parent/class families selectable and sort newer families first
- retain legacy options as a fallback for groups with no recent parseable family
- preserve existing old selections during edit and duplicate flows
- apply the same selectable-batch rule to quiz, live-class, and table filter options
- retain the full catalogue internally so historical session rows still resolve batch names

## Why

Quiz Creator previously called `/batch` without a limit. After db-service capped unbounded list requests at 1,000 rows, newer batches beyond that first ascending-ID page disappeared. Chhattisgarh consequently showed four older batch families while its newer 2027 and 2028 test-series families were omitted.

`start_date` is missing for many batches, while `inserted_at` is neither exposed by `/batch` nor semantically reliable after historical imports. The cohort year embedded in `batch_id` is present for 1,160 of 1,188 production batches and aligns with the session creator's operational use.

## Impact

Teachers and managers see recent quiz and class batch families first across create, edit, duplicate, quiz, and live-class flows. Older batches remain available for rendering historical sessions, and an existing legacy selection remains visible while editing.

## Validation

- `npm run test:jest -- --runInBand` (17 tests passed)
- `npm run lint:check`
- `npm run format:check`
- `npm run build`
- `git diff --check`
