### PR TITLE
fix(session): accept a CMS test URL carrying only an id

### DIFF
--- a/src/types/form.types.test.ts
+++ b/src/types/form.types.test.ts
@@ -20,8 +20,24 @@ describe('isValidCmsUrl', () => {
     ).toBe(true);
   });
 
-  it('rejects new-CMS links missing ingest parameters', () => {
-    expect(isValidCmsUrl('https://new-cms.avantifellows.org/tests/edit-test?id=504')).toBe(false);
+  it('accepts short new-CMS links carrying only a test id', () => {
+    // The CMS shortened its test links to `/test?id=<id>` (nex-gen-cms #170).
+    expect(isValidCmsUrl('https://new-cms.avantifellows.org/test?id=8901')).toBe(true);
+    expect(isValidCmsUrl('https://new-cms.avantifellows.org/tests/edit-test?id=504')).toBe(true);
+  });
+
+  it('still validates curriculum_id / grade_id when they are present', () => {
+    expect(isValidCmsUrl('https://new-cms.avantifellows.org/test?id=504&curriculum_id=0')).toBe(
+      false
+    );
+    expect(isValidCmsUrl('https://new-cms.avantifellows.org/test?id=504&grade_id=abc')).toBe(false);
+  });
+
+  it('rejects new-CMS links with no test id', () => {
+    expect(isValidCmsUrl('https://new-cms.avantifellows.org/test?curriculum_id=9&grade_id=2')).toBe(
+      false
+    );
+    expect(isValidCmsUrl('https://new-cms.avantifellows.org/test?id=abc')).toBe(false);
   });
 
   it('rejects unrelated hosts and new-CMS pages', () => {

--- a/src/types/form.types.ts
+++ b/src/types/form.types.ts
@@ -20,16 +20,26 @@ const LEGACY_CMS_HOST = 'cms.peerlearning.com';
 const NEW_CMS_HOSTS = new Set(['new-cms.avantifellows.org', 'staging-new-cms.avantifellows.org']);
 const NEW_CMS_TEST_PATHS = new Set(['/test', '/tests/edit-test']);
 
+function isPositiveIntParam(url: URL, key: string, required: boolean): boolean {
+  const rawValue = url.searchParams.get(key);
+  if (rawValue === null) return !required;
+  return /^\d+$/.test(rawValue) && Number(rawValue) > 0;
+}
+
 export function isValidCmsUrl(value: string): boolean {
   try {
     const url = new URL(value);
     if (url.hostname === LEGACY_CMS_HOST) return true;
     if (!NEW_CMS_HOSTS.has(url.hostname) || !NEW_CMS_TEST_PATHS.has(url.pathname)) return false;
 
-    return ['id', 'curriculum_id', 'grade_id'].every((key) => {
-      const rawValue = url.searchParams.get(key);
-      return rawValue !== null && /^\d+$/.test(rawValue) && Number(rawValue) > 0;
-    });
+    // Only the test id is required: the CMS shortened its test links to `/test?id=<id>`
+    // (nex-gen-cms #170) and a problem belongs to exactly one curriculum (db-service #651),
+    // so curriculum/grade never selected content. They stay validated when present.
+    return (
+      isPositiveIntParam(url, 'id', true) &&
+      isPositiveIntParam(url, 'curriculum_id', false) &&
+      isPositiveIntParam(url, 'grade_id', false)
+    );
   } catch {
     return false;
   }


### PR DESCRIPTION
## Problem

nex-gen-cms **#170** shortened its test links to `/test?id=<id>`, so **copying a link straight from the CMS UI produced exactly the URL this form rejected**:

> Please provide a valid legacy or new CMS test URL

The message gave no hint that the real problem was the missing `curriculum_id`/`grade_id` — the URL is a perfectly valid CMS test link.

## Why only the id is needed

Per db-service **#651**: *"every problem can have exactly one `resource_curriculum` row, hence filtering is not required on `curriculum_id`"*. Verified against prod — test 8901 (tagged to two curriculum-grade pairs) returns a byte-identical payload for either real pair or for nonsense values, and `grade_id` is unused entirely. quiz-backend now takes both as optional (avantifellows/quiz-backend#174).

## Change

`isValidCmsUrl` requires only a positive integer `id` for new-CMS hosts. `curriculum_id`/`grade_id` are **still validated when present**, so a malformed full link (`curriculum_id=0`, `grade_id=abc`) is still rejected. Host and path checks are unchanged; legacy `cms.peerlearning.com` links are unaffected.

quiz-creator only validates the URL — it stores it as `cms_test_id` and never extracts the params (sessionCreator does that downstream), so this is the whole fix on this side.

## Tests

`form.types.test.ts` — added: short `/test?id=` and `/tests/edit-test?id=` accepted; present-but-invalid curriculum/grade rejected; missing/invalid id rejected. The old "rejects links missing ingest parameters" case asserted the now-valid short link was invalid, so it was replaced. 8 passed; `tsc` clean on the source.

## Dependency — satisfied

db-service #677 (issue #651) is merged and on `release`; re-verified against prod that `/api/service/test?id=8901` alone returns 200 with all 180 problems. So a short link now works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)