### PR TITLE
fix(session): show class batches for non-quiz platforms

### DIFF
--- a/src/app/session/[type]/Steps/Basic/index.tsx
+++ b/src/app/session/[type]/Steps/Basic/index.tsx
@@ -25,6 +25,7 @@ import {
   handleRedirectionData,
   handleSignUpFields,
   classBatchOptionsFor,
+  nonQuizClassBatchOptionsFor,
   setGroupPreset,
   setParentBatchOptions,
 } from '../helper';
@@ -190,14 +191,15 @@ const BasicForm: FC = () => {
         label: 'Class Batch',
         disabled: type === SessionType.EDIT,
         options: currentBatchOptions.subBatchOptions,
-        // Class batches are the union of the children of every selected Quiz Batch, so
-        // they follow the LIVE form values — on create there is no saved session data to
-        // read, and for non-quiz platforms this field lists batches directly (no parent),
-        // so fall through to the statically computed options there.
+        // Both branches follow the LIVE form values: on create there is no saved session
+        // to read, so deriving from `formData` left this dropdown empty as soon as a
+        // group was picked. For Quiz the options are the union of the selected Quiz
+        // Batches' children; for every other platform they are the group's child batches
+        // directly, since those sessions have no Quiz Batch field.
         deriveOptions: (values) =>
           values.platform === Platform.Quiz
             ? classBatchOptionsFor(values.parentBatch, apiOptions)
-            : currentBatchOptions.subBatchOptions,
+            : nonQuizClassBatchOptionsFor(values.group, apiOptions),
       },
       grade: {
         type: 'select',

--- a/src/app/session/[type]/Steps/helper.ts
+++ b/src/app/session/[type]/Steps/helper.ts
@@ -16,6 +16,18 @@ import {
 import { isSelectableBatchOption } from '@/lib/batch-options';
 import { UseFormReturn } from 'react-hook-form';
 
+/**
+ * School-facing groups own no batches of their own: their sessions target the batches of
+ * the corresponding student group. Mirrors the per-group special cases in
+ * `setParentBatchOptions`.
+ */
+export const BATCH_GROUP_ALIASES: Partial<Record<Group, Group>> = {
+  [Group.TNSchools]: Group.TNStudents,
+  [Group.GujaratSchools]: Group.GujaratStudents,
+  [Group.PunjabSchools]: Group.PunjabStudents,
+  [Group.EnableSchools]: Group.Enable,
+};
+
 export const setGroupPreset = (value: string, form: UseFormReturn, apiOptions: ApiFormOptions) => {
   if (!value) return;
 
@@ -244,6 +256,32 @@ export const classBatchOptionsFor = (
   return (
     apiOptions?.batch?.filter(
       (item) => quizBatchIds.has(item.parentId) && isSelectableBatchOption(item)
+    ) ?? []
+  );
+};
+
+/**
+ * The class batches selectable for a non-quiz (Live Classes) session: every CHILD batch
+ * belonging to the selected group.
+ *
+ * Non-quiz platforms have no Quiz Batch field to hang the list off, so the group alone
+ * determines it. Pure and driven by the LIVE `group` value for the same reason as
+ * `classBatchOptionsFor`: computing it from the saved session left the dropdown empty
+ * whenever the group had only just been picked, which is always the case on create.
+ */
+export const nonQuizClassBatchOptionsFor = (
+  selectedGroup: string | undefined,
+  apiOptions: ApiFormOptions
+): ExtendedOptions[] => {
+  if (!selectedGroup) return [];
+
+  const batchGroupValue = BATCH_GROUP_ALIASES[selectedGroup as Group] ?? selectedGroup;
+  const batchGroupId = apiOptions.group?.find((item) => item.value === batchGroupValue)?.id;
+  if (batchGroupId == null) return [];
+
+  return (
+    apiOptions?.batch?.filter(
+      (item) => item.groupId === batchGroupId && !!item.parentId && isSelectableBatchOption(item)
     ) ?? []
   );
 };

--- a/src/app/session/[type]/Steps/nonQuizBatchOptions.test.ts
+++ b/src/app/session/[type]/Steps/nonQuizBatchOptions.test.ts
@@ -1,0 +1,98 @@
+import { nonQuizClassBatchOptionsFor } from './helper';
+import { ApiFormOptions, ExtendedOptions, Group } from '@/types';
+
+/**
+ * Live Classes bug: for any platform other than Quiz, the Class Batch dropdown stayed
+ * empty once a group was picked.
+ *
+ * The options were computed from `formData` (the SAVED session) while the user's group
+ * lived in live form state, so on create — nothing saved yet — the list came out empty.
+ * `nonQuizClassBatchOptionsFor` takes the live group instead.
+ */
+
+const batchOption = (
+  value: string,
+  id: string,
+  groupId: string,
+  parentId: string | null = null,
+  extra: Partial<ExtendedOptions> = {}
+): ExtendedOptions =>
+  ({
+    value,
+    label: value,
+    name: value,
+    id,
+    groupId,
+    parentId,
+    ...extra,
+  }) as unknown as ExtendedOptions;
+
+const ENABLE_ID = '3';
+const PUNJAB_ID = '8';
+
+const EN_PARENT = batchOption('EN-TP-2027-common-A01', '918', ENABLE_ID);
+const EN_CHILD_A = batchOption('EnableStudents_TP_2027_engg_A001', '920', ENABLE_ID, '918');
+const EN_CHILD_B = batchOption('EnableStudents_TP_2027_none_A001', '928', ENABLE_ID, '918');
+const PJ_PARENT = batchOption('PJ-TP-2027-common-A01', '831', PUNJAB_ID);
+const PJ_CHILD = batchOption('PunjabStudents_TP_2027_common_A001', '843', PUNJAB_ID, '831');
+const EN_CHILD_EXPIRED = batchOption('EnableStudents_TP_2019_old_A001', '500', ENABLE_ID, '918', {
+  isSelectableBatch: false,
+});
+
+const apiOptions = {
+  group: [
+    { value: Group.Enable, label: 'EnableStudents', id: ENABLE_ID },
+    { value: Group.PunjabStudents, label: 'PunjabStudents', id: PUNJAB_ID },
+    { value: Group.EnableSchools, label: 'EnableSchools', id: '30' },
+  ],
+  batch: [EN_PARENT, EN_CHILD_A, EN_CHILD_B, PJ_PARENT, PJ_CHILD, EN_CHILD_EXPIRED],
+} as unknown as ApiFormOptions;
+
+const valuesOf = (options: ExtendedOptions[]) => options.map((option) => option.value);
+
+describe('nonQuizClassBatchOptionsFor', () => {
+  it('lists the selected group’s child batches (the Live Classes fix)', () => {
+    expect(valuesOf(nonQuizClassBatchOptionsFor(Group.Enable, apiOptions))).toEqual([
+      'EnableStudents_TP_2027_engg_A001',
+      'EnableStudents_TP_2027_none_A001',
+    ]);
+  });
+
+  it('excludes parent (quiz) batches', () => {
+    const options = nonQuizClassBatchOptionsFor(Group.Enable, apiOptions);
+
+    expect(valuesOf(options)).not.toContain('EN-TP-2027-common-A01');
+    options.forEach((option) => expect(option.parentId).toBeTruthy());
+  });
+
+  it('excludes other groups’ batches', () => {
+    expect(valuesOf(nonQuizClassBatchOptionsFor(Group.Enable, apiOptions))).not.toContain(
+      'PunjabStudents_TP_2027_common_A001'
+    );
+    expect(valuesOf(nonQuizClassBatchOptionsFor(Group.PunjabStudents, apiOptions))).toEqual([
+      'PunjabStudents_TP_2027_common_A001',
+    ]);
+  });
+
+  it('excludes expired batches', () => {
+    expect(valuesOf(nonQuizClassBatchOptionsFor(Group.Enable, apiOptions))).not.toContain(
+      'EnableStudents_TP_2019_old_A001'
+    );
+  });
+
+  it('resolves school groups to their student group’s batches', () => {
+    expect(valuesOf(nonQuizClassBatchOptionsFor(Group.EnableSchools, apiOptions))).toEqual([
+      'EnableStudents_TP_2027_engg_A001',
+      'EnableStudents_TP_2027_none_A001',
+    ]);
+  });
+
+  it('returns nothing when no group is selected yet', () => {
+    expect(nonQuizClassBatchOptionsFor(undefined, apiOptions)).toEqual([]);
+    expect(nonQuizClassBatchOptionsFor('', apiOptions)).toEqual([]);
+  });
+
+  it('returns nothing for a group that is not in the options', () => {
+    expect(nonQuizClassBatchOptionsFor('NotARealGroup', apiOptions)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The bug

On the **Live Classes** side, picking any platform other than Quiz and then a group left the **Class Batch** dropdown empty — so those sessions couldn't be created at all.

## Why

`subBatch`'s options were computed from `formData` — the **saved session** — while the group the teacher just picked exists only in **live form state**. On create nothing is saved yet, so `formData.meta_data.group` is `undefined`, `getBatchOptions` returns early with `[]`, and the dropdown has nothing to show.

The Quiz path was unaffected because it already read live values through `deriveOptions`:

```js
deriveOptions: (values) =>
  values.platform === Platform.Quiz
    ? classBatchOptionsFor(values.parentBatch, apiOptions)  // live ✓
    : currentBatchOptions.subBatchOptions,                   // from formData ✗
```

## Why earlier attempts didn't stick

`setParentBatchOptions` tries to fix this by mutating `fieldsSchema.subBatch.options`. That can never work — `FormBuilder` memoises the field schema on `[type, label]`, and `subBatch` is always `multi-select` / `"Class Batch"`, so the memo never invalidates. The mutation is written and never read.

Both `helper.ts` and `FormBuilder.tsx` already document this trap; the non-quiz branch just never got migrated to the pattern those comments prescribe.

## The fix

Adds `nonQuizClassBatchOptionsFor(group, apiOptions)` — pure and live-value-driven, mirroring `classBatchOptionsFor`. It:

- returns the group's **child** batches (non-quiz sessions target class batches directly, with no Quiz Batch field to hang them off)
- excludes expired batches via the existing `isSelectableBatchOption`
- resolves school-facing groups to their student group's batches (`EnableSchools` → `EnableStudents`) through a new `BATCH_GROUP_ALIASES` map, extracted from the four duplicated special cases in `setParentBatchOptions`

## Testing

7 new unit tests in `nonQuizBatchOptions.test.ts` covering the fix, parent-batch exclusion, group isolation, expired batches, school-group aliasing, and the no-group-selected case. Full suite **48/48 passing**. Verified 930 class batches exist in prod across groups, so the dropdown has real data to populate from.

**Not yet clicked through in a running app** — worth a manual check on a Live Class create before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)